### PR TITLE
Display correct totals for expenses

### DIFF
--- a/finance_details/averages.php
+++ b/finance_details/averages.php
@@ -4,8 +4,6 @@
 <link rel='stylesheet' type='text/css' href='css/details.css' />
 <title>Averages</title>
 
-
-
 <div class="grid-container_avg" ; id="grid_format">
 
     <?php
@@ -14,31 +12,26 @@
     $categories->execute();
 
     foreach ($categories as $row) {
-        // $name = $row['expense_name'];
-        // $category = $row['expense_category'];
         $type = $row['expense_type'];
-        // $frequency = $row['payment_frequency'];
         getTotals($pdo, $type);
     }
 
     function getTotals($pdo, $type)
     {
-        $get_avg = $pdo->prepare("SELECT item_purchased, kind, ROUND(AVG(month_spend), 2) AS avg_cost
-                                    FROM (SELECT item_purchased, kind, DATE_TRUNC('month',purchase_date) AS  buy_month, sum(amount) AS month_spend
-                                        FROM expenses
-                                        -- WHERE purchase_date > CURRENT_DATE - INTERVAL '12 months' AND kind = :expkind
-                                        -- WHERE purchase_date BETWEEN purchase_date AND NOW() AND item_purchased = 'Mortgage'
-                                        WHERE purchase_date BETWEEN purchase_date AND NOW() AND kind = :expkind
-                                        GROUP BY item_purchased, kind, DATE_TRUNC('month', purchase_date)
-                                        ORDER BY buy_month) AS monthly_average
-                                    GROUP BY item_purchased, kind
+        $get_avg = $pdo->prepare("SELECT item_purchased
+                                    FROM (SELECT item_purchased, DATE_TRUNC('month',purchase_date) AS buy_month, sum(amount) AS month_spend
+                                          FROM expenses
+                                          WHERE purchase_date >= CURRENT_DATE - INTERVAL '1 year' AND purchase_date <= CURRENT_DATE AND kind = :expkind
+                                          GROUP BY item_purchased, kind, purchase_date
+                                          ORDER BY buy_month) AS monthly_average
+                                    GROUP BY item_purchased
                                     ORDER BY item_purchased;");
         $get_avg->execute(['expkind' => $type]);
     ?>
 
         <table class="table_avg">
             <tr>
-                <th colspan="4"; class='heading'>
+                <th colspan="4" ; class='heading'>
                     <?php echo $type . "<br>Expenses"; ?>
                 </th>
             </tr>
@@ -50,11 +43,12 @@
             </tr>
 
         <?php
-        $get_payments = $pdo->prepare("SELECT round(sum(amount), 2) AS year_spend, count(amount) AS numb_payments FROM expenses WHERE item_purchased = :exp_name;");
+        $get_payments = $pdo->prepare("SELECT round(sum(amount), 2) AS year_spend, count(amount) AS numb_payments FROM expenses WHERE purchase_date > NOW() - INTERVAL '1 year' AND purchase_date < NOW() AND item_purchased = :exp_name;");
         $get_expense = $pdo->prepare("SELECT payment_frequency, expense_type FROM expense_categories WHERE expense_name = :exp_name;");
 
         foreach ($get_avg as $row) {
             $exp_name = $row['item_purchased'];
+
             $get_payments->execute(['exp_name' => $exp_name]);
             while ($row_get = $get_payments->fetch()) {
                 $year_total = $row_get['year_spend'];
@@ -66,7 +60,7 @@
                 $frequency = $rows['payment_frequency'];
             }
 
-            if ($frequency == 1 or $frequency == 4 OR $type == 'Variable') {
+            if ($frequency == 1 or $frequency == 4 or $type == 'Variable') {
                 $monthly = $year_total / 12;
                 $bimonthly = $year_total / 12 / 2;
             } elseif ($frequency == 6) {


### PR DESCRIPTION
Monthly totals were including expenses that had yet to happen; but had been entered in system. Now only takes totals between the current day and current day less 1 year.